### PR TITLE
Various updates

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,8 @@ class pgbouncer::config {
     mode  => 0644,
   }
 
+  $db_users = $::pgbouncer::db_users
+
   # install pgbouncer permissions
   file { '/etc/pgbouncer/userlist.txt':
     content => template('pgbouncer/userlist.txt.erb'),
@@ -13,7 +15,7 @@ class pgbouncer::config {
     group   => $pgbouncer::group,
     mode    => '0640',
   }
-  
+
   concat::fragment { "${config}-header":
     target  => $config,
     content => '# MANAGED BY PUPPET',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,7 @@ class pgbouncer (
       },
       'version' => {
         'type'    => 'str',
-        'pattern' => '/^[-~.\w_\d]+$/',
+        'pattern' => '/^[+-~.\w_\d]+$/',
         'required' => true,
       },
       'db_users' => {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,7 +1,7 @@
 class pgbouncer::package {
   file { '/etc/init.d/pgbouncer':
     ensure => present,
-    source => 'puppet:///pgbouncer/init-pgbouncer.sh',
+    source => 'puppet:///modules/pgbouncer/init-pgbouncer.sh',
     mode   => '0755',
     owner  => 'root',
     group  => 'root',


### PR DESCRIPTION
- add modules/ prefix to the init.d file resource: This is according to http://docs.puppetlabs.com/references/latest/type.html#file-attribute-source This didn't work on Puppet 3.4+ without it.
- db_users does not exist in the config context: This change grabs the passed parameters from init.pp
- Add the '+' symbol to the version regular expression: When getting pgbouncer from postgres (
  http://apt.postgresql.org/pub/repos/apt/pool/main/p/pgbouncer/ ) there
  is a '+' in the version. Kwalify failed before this regex was updated.
